### PR TITLE
feat: create README-based development plan

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,1 +1,43 @@
-#plan
+# Quanta_Pie Development Plan
+
+This document outlines the development plan for the Quanta_Pie project, a text-based C++ adventure game.
+
+## Phase 1: Core Engine Development
+- **Objective:** Build the foundational C++ engine for the game.
+- **Activities:**
+    - Implement the main game loop.
+    - Create a robust text parser for player input.
+    - Develop a state management system to track player progress and game world status.
+    - Design a modular structure to allow for easy expansion of the story and features.
+
+## Phase 2: Story and Content Creation
+- **Objective:** Develop the narrative and game world.
+- **Activities:**
+    - Write the main storyline and branching narrative paths.
+    - Create detailed descriptions of locations, characters, and items.
+    - Define the puzzles and challenges within the game.
+    - Ensure the story aligns with the themes of the Quanta Series.
+
+## Phase 3: Feature Implementation
+- **Objective:** Implement the key gameplay features.
+- **Activities:**
+    - Code the logic for dynamic story paths based on player choices.
+    - Implement the system for multiple endings.
+    - Add any additional gameplay mechanics, such as an inventory system or character stats.
+    - Integrate the story content with the core engine.
+
+## Phase 4: Gameplay and Balance Testing
+- **Objective:** Test the game for bugs, and to ensure a compelling gameplay experience.
+- **Activities:**
+    - Conduct thorough playthroughs of all story branches.
+    - Identify and fix any bugs or logical inconsistencies in the narrative.
+    - Balance the difficulty of puzzles and challenges.
+    - Gather feedback from playtesters to improve the game.
+
+## Phase 5: Build System and Release
+- **Objective:** Finalize the build process and prepare the game for release.
+- **Activities:**
+    - Create a cross-platform build system (e.g., using CMake).
+    - Write clear and comprehensive build and run instructions in the README.md.
+    - Package the game for distribution.
+    - Tag a version 1.0 release.


### PR DESCRIPTION
The development plan in docs/plan.md has been updated to be based on the information in README.md, tailored to the Quanta_Pie project.